### PR TITLE
Implementing a simple strategy for avoiding duplicate move

### DIFF
--- a/pysollib/stack.py
+++ b/pysollib/stack.py
@@ -2162,11 +2162,6 @@ class OpenStack(Stack):
                 break
             if self.canMoveCards(cards):
                 for s in stacks:
-                    # Ignore if we are moving entire stack into
-                    # another stack that is fully empty
-                    if i == len(self.cards) and len(s.cards) == 0:
-                        continue
-
                     if s is not self and s.acceptsCards(self, cards):
                         return (s, i)
         return (None, 0)


### PR DESCRIPTION
First revert "fix stuck loop move into empty spot", because this change actually introduce a bug where we can't move a card from tableau() to foundation(), if the column has only 1 card and foundation() is empty. The next solution should fix what this commit is intended to fix.

For starter, we generate a state string composed of top cards
from waste, foundation stacks and tableau stacks. We keep the
state in a HashSet.

One design decision is, if we know the next move will enter
duplicated state, should we stop this move? The answer is No.
Reason is: if we prevent any move to a duplicated state, then
the duplicated state will never be entered. But there might be
valid path in the duplicated state that isn't fully explored yet.
Unless we keep track of all available path in each state, and
make sure all moves in that state is exhausted, we can't forbid
going into the duplicated state.

Therefore in the current implementation, we sort of prevent entering
the duplicated state. Only when we move multiple stacks to multiple
stacks, we examine the source stacks, and find the best candidate
to move to destination stacks. The duplicated state will be used
when deciding the best candidate. If moving from a single stack
to multiple stacks, we allow moving even if it will enter duplicated
state.